### PR TITLE
Add dictionary attack mitigations to security considerations (resolves #14)

### DIFF
--- a/draft-bmw-tls-pake13.md
+++ b/draft-bmw-tls-pake13.md
@@ -204,7 +204,7 @@ If the server has a PAKEScheme in common with the client then the server uses
 the client_identity and server_identity alongside its local database of PAKE
 registration information to determine if the request corresponds to a legitimate
 client registration record. If one does not
-exist, the server simulates a PAKE response as described in {{simulation}}.
+exist, the server MAY simulate a PAKE response as described in {{simulation}}.
 Simulating a response prevents client enumeration attacks on the server's
 PAKE database; see {{security}}.
 
@@ -400,14 +400,16 @@ guess the low-entropy secret.
 
 Clients and servers should apply mitigations against dictionary attacks.
 Reasonable mitigations include rate-limiting authentication attempts,
-imposing a backoff time between attempts, or limiting the total number
+imposing a backoff time between attempts, limiting the
+number of failed attempts, or limiting the total number
 of attempts.
 
-Clients should treat each time they receive an invalid PAKEServerHello
-as a failed authentication attempt for the identity sent in the previously sent PAKEClientHello.
-Servers should treat each time they send a PAKEServerHello extension but do not
-subsequently receive a correct Finished message from the client as a
-failed authentication attempt for the identity in the previously received PAKEClientHello.
+Clients SHOULD treat each time they receive an invalid PAKEServerHello
+as a failed authentication attempt for the identity in the previously sent PAKEClientHello.
+Servers SHOULD treat each time they send a PAKEServerHello extension as a failed
+authentication attempt for the selected identity, until they receive a correct Finished
+message from the client. Once the server receives a correct Finished message,
+the authentication attempt MAY be treated as successful.
 
 ## Protection of client identities
 

--- a/draft-bmw-tls-pake13.md
+++ b/draft-bmw-tls-pake13.md
@@ -254,8 +254,7 @@ To simulate a fake PAKE response, the server does the following:
 * Include the `pake` extension in its ServerHello, containing a PAKEShare value with
 the selected PAKEScheme and corresponding `pake_message`. To generate the `pake_message`
 for this `PAKEShare` value, the server selects a value uniformly at random from
-the set of possible values of the PAKE algorithm shares. For example, for SPAKE2+,
-this would be a random point on the elliptic curve group.
+the set of possible values of the PAKE algorithm shares.
 * Perform the rest of the protocol as normal.
 
 Because the server's share was selected uniformly at random, the server will reject
@@ -369,6 +368,7 @@ as the `(EC)DHE` input to the key schedule in {{Section 7.1 of !TLS13=RFC8446}},
 
 Note that the server does compute and send confirmV as defined in {{Section 3.4 of SPAKE2PLUS}}
 since it can do so within the structure of the TLS 1.3 handshake and the client MUST verify it.
+If verification of confirmV fails, clients SHOULD abort the handshake with a "decrypt_error" alert.
 The client and server do not additionally compute or verify confirmP
 as described in {{Section 3.4 of SPAKE2PLUS}}.
 See {{spake2plus-sec}} for more information about the safety of this approach.
@@ -425,8 +425,7 @@ to learn whether the server recognizes a given identity.
 
 Alternatively, if the server wishes to hide the fact that a client
 identity is unrecognized, the server MAY simulate the protocol as
-if an identity was recognized, but then reject the client's
-Finished message with a "decrypt_error" alert, as if the password was incorrect.
+if an identity was recognized, but the password was incorrect.
 This is similar to the procedure outlined in {{?RFC5054}}.
 The simulation mechanism is described in {{simulation}}.
 

--- a/draft-bmw-tls-pake13.md
+++ b/draft-bmw-tls-pake13.md
@@ -253,7 +253,7 @@ To simulate a fake PAKE response, the server does the following:
 * Select a PAKEScheme supported by the client and server, as normal.
 * Include the `pake` extension in its ServerHello, containing a PAKEShare value with
 the selected PAKEScheme and corresponding `pake_message`. To generate the `pake_message`
-for this `PAKEShare` value, the server should select a value uniformly at random from
+for this `PAKEShare` value, the server selects a value uniformly at random from
 the set of possible values of the PAKE algorithm shares. For example, for SPAKE2+,
 this would be a random point on the elliptic curve group.
 * Perform the rest of the protocol as normal.
@@ -398,7 +398,7 @@ Because PAKE security is based on knowledge of a low-entropy secret,
 an attacker can perform a "dictionary attack" by repeatedly attempting to
 guess the low-entropy secret.
 
-Clients and servers should apply mitigations against dictionary attacks.
+Clients and servers SHOULD apply mitigations against dictionary attacks.
 Reasonable mitigations include rate-limiting authentication attempts,
 imposing a backoff time between attempts, limiting the
 number of failed attempts, or limiting the total number


### PR DESCRIPTION
Adds language to security considerations on what counts as a failed authentication attempt for the purposes of mitigating dictionary attacks. Also fixes a small point in the simulation text.

Resolves #14.